### PR TITLE
Use std::optional

### DIFF
--- a/Particle.cpp
+++ b/Particle.cpp
@@ -3,14 +3,14 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
-#include <memory>
+#include <optional>
 
 #include "ParticleType.hpp"
 #include "ResonanceType.hpp"
 
 // init static members
 
-std::array<std::unique_ptr<ParticleType>, 10> Particle::m_particle_types{};
+std::array<std::optional<ParticleType>, 10> Particle::m_particle_types{};
 
 // momentum operators
 
@@ -72,7 +72,7 @@ void Particle::setIndex(std::string const& name) {
 }
 
 void Particle::setIndex(int index) {
-  m_index = m_particle_types[index] == nullptr ? -1 : index;
+  m_index = m_particle_types[index] == std::nullopt ? -1 : index;
 }
 
 void Particle::setMomentum(double px, double py, double pz) {
@@ -86,7 +86,7 @@ void Particle::setMomentum(Momentum const& momentum) { m_momentum = momentum; }
 int Particle::countParticleTypes() {
   return std::count_if(
       m_particle_types.begin(), m_particle_types.end(),
-      [](std::unique_ptr<ParticleType> const& pt) { return pt != nullptr; });
+      [](std::optional<ParticleType> const& pt) { return pt != std::nullopt; });
 }
 
 void Particle::addParticleType(std::string const& name, double mass, int charge,
@@ -94,15 +94,13 @@ void Particle::addParticleType(std::string const& name, double mass, int charge,
   auto existing_index = mFindParticleIndex(name);
 
   if (existing_index == -1) {
-    auto first_empty =
-        std::find(m_particle_types.begin(), m_particle_types.end(), nullptr);
+    auto first_empty = std::find(m_particle_types.begin(),
+                                 m_particle_types.end(), std::nullopt);
 
     if (width == 0) {
-      *first_empty =
-          std::unique_ptr<ParticleType>(new ParticleType{name, mass, charge});
+      *first_empty = ParticleType{name, mass, charge};
     } else {
-      *first_empty = std::unique_ptr<ParticleType>(
-          new ResonanceType{name, mass, charge, width});
+      *first_empty = ResonanceType{name, mass, charge, width};
     }
   } else {
     std::cout << "The \"" << name << "\" particle type already exists!" << '\n';
@@ -122,8 +120,8 @@ void Particle::printParticleTypes() {
 
 int Particle::mFindParticleIndex(std::string const& name) {
   auto it = std::find_if(m_particle_types.begin(), m_particle_types.end(),
-                         [&name](std::unique_ptr<ParticleType> const& pt) {
-                           if (pt) {
+                         [&name](std::optional<ParticleType> const& pt) {
+                           if (pt != std::nullopt) {
                              return pt->getName() == name;
                            }
 

--- a/Particle.cpp
+++ b/Particle.cpp
@@ -3,13 +3,14 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <memory>
 
 #include "ParticleType.hpp"
 #include "ResonanceType.hpp"
 
 // init static members
 
-std::array<ParticleType*, 10> Particle::m_particle_types{};
+std::array<std::unique_ptr<ParticleType>, 10> Particle::m_particle_types{};
 
 // momentum operators
 
@@ -83,8 +84,9 @@ void Particle::setMomentum(Momentum const& momentum) { m_momentum = momentum; }
 // static methods
 
 int Particle::countParticleTypes() {
-  return std::count_if(m_particle_types.begin(), m_particle_types.end(),
-                       [](ParticleType* const& pt) { return pt != nullptr; });
+  return std::count_if(
+      m_particle_types.begin(), m_particle_types.end(),
+      [](std::unique_ptr<ParticleType> const& pt) { return pt != nullptr; });
 }
 
 void Particle::addParticleType(std::string const& name, double mass, int charge,
@@ -96,9 +98,11 @@ void Particle::addParticleType(std::string const& name, double mass, int charge,
         std::find(m_particle_types.begin(), m_particle_types.end(), nullptr);
 
     if (width == 0) {
-      *first_empty = new ParticleType{name, mass, charge};
+      *first_empty =
+          std::unique_ptr<ParticleType>(new ParticleType{name, mass, charge});
     } else {
-      *first_empty = new ResonanceType{name, mass, charge, width};
+      *first_empty = std::unique_ptr<ParticleType>(
+          new ResonanceType{name, mass, charge, width});
     }
   } else {
     std::cout << "The \"" << name << "\" particle type already exists!" << '\n';
@@ -118,7 +122,7 @@ void Particle::printParticleTypes() {
 
 int Particle::mFindParticleIndex(std::string const& name) {
   auto it = std::find_if(m_particle_types.begin(), m_particle_types.end(),
-                         [&name](ParticleType* const& pt) {
+                         [&name](std::unique_ptr<ParticleType> const& pt) {
                            if (pt) {
                              return pt->getName() == name;
                            }

--- a/Particle.hpp
+++ b/Particle.hpp
@@ -2,7 +2,7 @@
 #define PARTICLE_HPP
 
 #include <array>
-#include <memory>
+#include <optional>
 #include <string>
 
 class ParticleType;
@@ -47,7 +47,7 @@ class Particle {
   Momentum m_momentum;
   int m_index;
 
-  static std::array<std::unique_ptr<ParticleType>, 10> m_particle_types;
+  static std::array<std::optional<ParticleType>, 10> m_particle_types;
   static int mFindParticleIndex(std::string const& name);
 };
 

--- a/Particle.hpp
+++ b/Particle.hpp
@@ -2,6 +2,7 @@
 #define PARTICLE_HPP
 
 #include <array>
+#include <memory>
 #include <string>
 
 class ParticleType;
@@ -46,7 +47,7 @@ class Particle {
   Momentum m_momentum;
   int m_index;
 
-  static std::array<ParticleType*, 10> m_particle_types;
+  static std::array<std::unique_ptr<ParticleType>, 10> m_particle_types;
   static int mFindParticleIndex(std::string const& name);
 };
 

--- a/ParticleType.hpp
+++ b/ParticleType.hpp
@@ -14,9 +14,9 @@ class ParticleType {
   virtual void print() const;
 
  private:
-  std::string const m_name;
-  double const m_mass;
-  int const m_charge;
+  std::string m_name;
+  double m_mass;
+  int m_charge;
 };
 
 #endif

--- a/ResonanceType.hpp
+++ b/ResonanceType.hpp
@@ -12,7 +12,7 @@ class ResonanceType : public ParticleType {
   void print() const override;
 
  private:
-  double const m_width;
+  double m_width;
 };
 
 #endif


### PR DESCRIPTION
Qui ho usato `std::optional` invece dei puntatori, ci permette di evitare qualsiasi tipo di problema di accesso alla memoria. In sostanza permette a un elemento dell'`array` di essere vuoto o popolato, senza la necessità di inizializzare l'array all'inizio del programma. Questa soluzione è utile solo nel caso in cui serva effettivamente avere un numero massimo di particelle, che io sospetto non sia necessario. Altrimenti si può fare un bellissimo `std::vector` che implementerò in una PR separata.